### PR TITLE
External mqtt rpc

### DIFF
--- a/AstralionBotTestStrat.py
+++ b/AstralionBotTestStrat.py
@@ -1,0 +1,304 @@
+# pragma pylint: disable=missing-docstring, invalid-name, pointless-string-statement
+# flake8: noqa: F401
+# isort: skip_file
+# --- Do not remove these libs ---
+import logging
+import numpy as np  # noqa
+import pandas as pd  # noqa
+from pandas import DataFrame
+
+from freqtrade.strategy import IStrategy
+from freqtrade.strategy import IntParameter
+# --------------------------------
+# Add your lib to import here
+import talib.abstract as ta
+import freqtrade.vendor.qtpylib.indicators as qtpylib
+from talib import MA_Type
+logger = logging.getLogger(__name__)
+
+
+class AstralionBotTestStrat(IStrategy):
+    # Strategy interface version - allow new iterations of the strategy interface.
+    # Check the documentation or the Sample strategy to get the latest version.
+    INTERFACE_VERSION = 2
+
+    # Minimal ROI designed for the strategy.
+    minimal_roi = {
+        "0": 0.139,
+        "40": 0.051,
+        "53": 0.025,
+        "157": 0
+    }
+
+    # Stoploss:
+    stoploss = -0.324
+
+    # Trailing stop:
+    trailing_stop = True
+    trailing_stop_positive = 0.01
+    trailing_stop_positive_offset = 0.034
+    trailing_only_offset_is_reached = True
+
+    ### Hyperoptable parameters
+    # SPACE BUY
+    buy_adx = IntParameter(18, 32, default=30, optimize=True, space="buy")
+    buy_macd = IntParameter(-10, 20, default=15, optimize=False, space="buy")
+
+    # ENABLER BUY
+    #buy_trigger_macd_increase_enabled = CategoricalParameter([True, False], default=False, optimize=True, space="buy")
+    #buy_trigger_macd_enabled = CategoricalParameter([True, False], default=False, optimize=True, space="buy")
+    #buy_trigger_cross = CategoricalParameter(["macd", "no_cross_cond"], default="no_cross_cond", optimize=True, space="buy")
+
+    # SPACE SELL
+    sell_adx = IntParameter(18, 32, default=27, optimize=False, space="sell")
+    sell_stochrsi = IntParameter(60, 87, default=61, optimize=False, space="sell")
+    #sell_macd = IntParameter(0, 30, default=7, optimize=True, space="sell")
+
+    # ENABLER SELL
+    # REPLACE BOLLINGER by KELTNER
+    #sell_trigger_macd_decrease_enabled = CategoricalParameter([True, False], default=True, optimize=True, space="sell")
+
+    buy_ema_short_period = IntParameter(3, 9, default=8, optimize=False, space="buy")
+    #sell_ema_short_period = IntParameter(3, 9, default=5, optimize=True, space="sell")
+
+    buy_ema_long_period = IntParameter(12, 30, default=29, optimize=False, space="buy")
+    #sell_ema_long_period = IntParameter(9, 30, default=20, optimize=True, space="sell")
+
+    # Strategy for 5m timeframe.
+    timeframe = '1m'
+
+    # Run "populate_indicators()" only for new candle.
+    process_only_new_candles = False
+
+    # These values can be overridden in the "ask_strategy" section in the config.
+    use_sell_signal = True
+    sell_profit_only = True
+    #ignore_roi_if_buy_signal = True # Overridden
+
+    # Number of candles the strategy requires before producing valid signals
+    startup_candle_count: int = 500
+
+    # Optional order type mapping.
+    order_types = {
+        'buy': 'limit',
+        'sell': 'limit',
+        'stoploss': 'limit',
+        'stoploss_on_exchange': False, # Gérer le stoploss directement dans freqtrade pour éviter la latence imposée par Binance (d'autant plus si je n'utilise plus les bougies par la suite)
+        'stoploss_on_exchange_interval': 60,
+        'stoploss_on_exchange_limit_ratio': 0.995
+    }
+
+    # Optional order time in force.
+    order_time_in_force = {
+        'buy': 'gtc',
+        'sell': 'gtc'
+    }
+
+    plot_config = {
+        'main_plot': {
+            'tema': {},
+            'sar': {'color': 'white'},
+        },
+        'subplots': {
+            "MACD": {
+                'macd': {'color': 'blue'},
+                'macdsignal': {'color': 'orange'},
+            },
+            "RSI": {
+                'rsi': {'color': 'red'},
+            }
+        }
+    }
+
+    def informative_pairs(self):
+        """
+        Define additional, informative pair/interval combinations to be cached from the exchange.
+        These pair/interval combinations are non-tradeable, unless they are part
+        of the whitelist as well.
+        For more information, please consult the documentation
+        :return: List of tuples in the format (pair, interval)
+            Sample: return [("ETH/USDT", "5m"),
+                            ("BTC/USDT", "15m"),
+                            ]
+        """
+        return []
+
+    def populate_indicators(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
+        """
+        Adds several different TA indicators to the given DataFrame
+
+        Performance Note: For the best performance be frugal on the number of indicators
+        you are using. Let uncomment only the indicator you are using in your strategies
+        or your hyperopt configuration, otherwise you will waste your memory and CPU usage.
+        :param dataframe: Dataframe with data from the exchange
+        :param metadata: Additional information, like the currently traded pair
+        :return: a Dataframe with all mandatory indicators for the strategies
+        """
+
+        # Momentum Indicators
+        # ------------------------------------
+
+        # ADX
+        dataframe['adx'] = ta.ADX(dataframe, timeperiod=14)
+
+        # MACD
+        macd  = ta.MACD(dataframe, fastperiod=12, slowperiod=26, signalperiod=9)
+        dataframe['macd'] = macd['macd']
+        dataframe['macdsignal'] = macd['macdsignal']
+        dataframe['macdhist'] = macd['macdhist']
+        dataframe['macd_previous_s'] = dataframe['macd'].shift(1)
+
+        stoch_rsi = ta.STOCHRSI(dataframe, timeperiod=14, fastk_period=5, fastd_period=3, fastd_matype=0)
+        dataframe['fastk_rsi'] = stoch_rsi['fastk']
+        dataframe['fastd_rsi'] = stoch_rsi['fastd']
+
+        dataframe['rsi'] = ta.RSI(dataframe, timeperiod=14)
+
+        upperband, middleband, lowerband = ta.BBANDS(dataframe['close'], timeperiod=20, nbdevup=2.0, nbdevdn=2.0, matype=MA_Type.T3)
+        dataframe['bb_up'] = upperband
+        dataframe['bb_lw'] = lowerband
+        dataframe['bb_mid'] = middleband
+
+
+        dataframe["ema_5"] = ta.EMA(dataframe, timeperiod=5)
+        dataframe["ema_20"] = ta.EMA(dataframe, timeperiod=20)
+
+        k = 30
+        dataframe["ema_5_history"] = [
+            dataframe['ema_5'].iloc[max(0, i - k + 1):i + 1].tolist() 
+            for i in range(len(dataframe))
+        ]
+        dataframe["ema_20_history"] = [
+            dataframe['ema_20'].iloc[max(0, i - k + 1):i + 1].tolist() 
+            for i in range(len(dataframe))
+        ]
+
+        dataframe["ema_10"] = ta.EMA(dataframe, timeperiod=10)
+        dataframe["ema_50"] = ta.EMA(dataframe, timeperiod=50)
+
+        # Create a new column with arrays of current + 29 previous EMA-50 values
+        dataframe["ema_50_history"] = [
+            dataframe['ema_50'].iloc[max(0, i - k + 1):i + 1].tolist() 
+            for i in range(len(dataframe))
+        ]
+
+        dataframe["ema_10_history"] = [
+            dataframe['ema_10'].iloc[max(0, i - k + 1):i + 1].tolist() 
+            for i in range(len(dataframe))
+        ]
+
+        dataframe["chaikin_ad_osc"] = ta.ADOSC(dataframe, fastperiod=3, slowperiod=10)
+
+        fastk, fastd = ta.STOCHF(
+            dataframe["high"], dataframe["low"], dataframe["close"], fastk_period=14, fastd_period=3, fastd_matype=0
+        )
+        dataframe["fastk"] = fastk
+        dataframe["fastd"] = fastd
+
+        #if (metadata['pair'] == 'BTC/USDT'):
+        #    print(dataframe)
+        #    print(dataframe.columns)
+        #    dataframe['json'] = dataframe.apply(lambda x: str(x.to_json()), axis=1)
+        #    print(dataframe.tail(1)['json'].values[0])
+            #print(stoch_rsi)
+            #print(dataframe['fastk_rsi'])
+            #print(dataframe['ema_var'])
+            #print(dataframe.columns)
+            #print(metadata)
+
+        return dataframe
+
+    def populate_entry_trend(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
+        """
+        Based on TA indicators, populates the buy signal for the given dataframe
+        :param dataframe: DataFrame populated with indicators
+        :param metadata: Additional information, like the currently traded pair
+        :return: DataFrame with buy column
+        """
+        #conditions = []
+
+        # Some "BUY" conditions
+        #if self.buy_trigger_macd_enabled.value  and (not self.buy_trigger_cross.value == "macd") and (not self.buy_trigger_macd_increase_enabled.value) :
+        #    conditions.append(dataframe['macd'] > self.buy_macd.value /100)
+        #if self.buy_trigger_macd_increase_enabled.value and (not self.buy_trigger_macd_enabled.value) and (not self.buy_trigger_cross.value == "macd"): #MACD increase et redressement du signal
+        #if self.buy_trigger_macd_enabled.value:
+        #conditions.append(dataframe['macd'] > dataframe['macd_previous_s'])
+        #conditions.append(dataframe['macd_previous_s'] >= dataframe['macd_previous_l'])
+        #if self.buy_trigger_cross.value == "macd":
+        #    conditions.append(qtpylib.crossed_above(dataframe['macd'], self.buy_macd.value/100))
+
+        #### GUARDS CONDITIONS
+        #conditions.append((dataframe['volume'] > 0)) #& (dataframe['adx'] > self.buy_adx.value))
+
+        #if conditions:
+        #    dataframe.loc[(
+        #        reduce(lambda x, y: x & y, conditions)),
+        #        'buy'] = 1
+
+        dataframe.loc[(
+                (
+                    (qtpylib.crossed_above(dataframe['macd'], self.buy_macd.value/100))
+                    | (
+                        (dataframe[f'ema_10'] >= dataframe[f'ema_5'])
+                        & ((dataframe['macd'] > dataframe['macd_previous_s']) | ((dataframe['ema_5'] < dataframe['ema_5'])))
+                    )
+                )
+                & dataframe['volume'] > 0 & (dataframe['adx'] > self.buy_adx.value)
+            ),
+            ['enter_long', 'enter_tag']] = (1, 'rsi_cross')
+
+        return dataframe
+
+
+    def populate_exit_trend(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
+        """
+        Based on TA indicators, populates the sell signal for the given dataframe
+        :param dataframe: DataFrame populated with indicators
+        :param metadata: Additional information, like the currently traded pair
+        :return: DataFrame with sell column
+        """
+
+        #conditions = []
+
+        ### Some "SELL" conditions
+
+        #if self.sell_trigger_macd_decrease_enabled.value:
+        #if dataframe['ema5'] < dataframe['ema20']:
+        #    conditions.append(dataframe['macd'] < dataframe['macd_previous_s'])
+        #else:
+        #   # If increase period, allow more resilience if check two frames than one
+        #    conditions.append(dataframe['macd'] < dataframe['macd_previous_s'])
+        #    conditions.append(dataframe['macd_previous_s'] <= dataframe['macd_previous_l'])
+        #else:
+        #    conditions.append(qtpylib.crossed_below(dataframe['macd'], self.sell_macd.value/100))
+        
+        ### GUARDS CONDITIONS
+        #conditions.append(dataframe['volume'] > 0)# & (dataframe['adx'] > self.sell_adx.value))
+
+        #if conditions:
+        #    dataframe.loc[(
+        #        reduce(lambda x, y: x & y, conditions)),
+        #        'sell'] = 1
+        dataframe.loc[((
+                qtpylib.crossed_below(dataframe['fastk_rsi'], self.sell_stochrsi.value)
+                ) & dataframe['volume'] > 0 & (dataframe['adx'] > self.sell_adx.value)
+            ),
+            ['exit_long', 'exit_tag']] = (1, 'some_exit_tag')
+
+        return dataframe
+
+
+    #use_custom_stoploss = True
+#
+#
+    #def custom_stoploss(self, pair: str, trade: Trade, current_time: datetime,
+    #                    current_rate: float, current_profit: float, **kwargs) -> float:
+#
+    #    # Pour chaque pair, optimisation du trailing stoploss/stoploss
+    #    if (current_profit > 0.0) & (current_profit < self.stpl_limit_sup.value /100) :
+    #        return self.stpl_val_inter.value /100
+    #    elif current_profit >= self.stpl_limit_sup.value /100:
+    #        return self.stpl_val_sup.value /1000
+    #    elif current_profit <= 0.0:
+    #        return self.stpl_val_inf.value /100
+    #    return 3 /100

--- a/Dockerfile.astralionbottest
+++ b/Dockerfile.astralionbottest
@@ -1,0 +1,58 @@
+FROM python:3.12.7-slim-bookworm as base
+
+# Setup env
+ENV LANG C.UTF-8
+ENV LC_ALL C.UTF-8
+ENV PYTHONDONTWRITEBYTECODE 1
+ENV PYTHONFAULTHANDLER 1
+ENV PATH=/home/ftuser/.local/bin:$PATH
+ENV FT_APP_ENV="docker"
+
+# Prepare environment
+RUN mkdir /freqtrade \
+  && apt-get update \
+  && apt-get -y install sudo libatlas3-base curl sqlite3 libhdf5-serial-dev libgomp1 \
+  && apt-get clean \
+  && useradd -u 1000 -G sudo -U -m -s /bin/bash ftuser \
+  && chown ftuser:ftuser /freqtrade \
+  # Allow sudoers
+  && echo "ftuser ALL=(ALL) NOPASSWD: /bin/chown" >> /etc/sudoers
+
+WORKDIR /freqtrade
+
+# Install dependencies
+FROM base as python-deps
+RUN  apt-get update \
+  && apt-get -y install build-essential libssl-dev git libffi-dev libgfortran5 pkg-config cmake gcc \
+  && apt-get clean \
+  && pip install --upgrade pip wheel
+
+# Install TA-lib
+COPY build_helpers/* /tmp/
+RUN cd /tmp && /tmp/install_ta-lib.sh && rm -r /tmp/*ta-lib*
+ENV LD_LIBRARY_PATH /usr/local/lib
+
+# Install dependencies
+COPY --chown=ftuser:ftuser requirements.txt requirements-hyperopt.txt /freqtrade/
+USER ftuser
+RUN  pip install --user --no-cache-dir "numpy<2.0" \
+  && pip install --user --no-cache-dir -r requirements-hyperopt.txt
+
+# Copy dependencies to runtime-image
+FROM base as runtime-image
+COPY --from=python-deps /usr/local/lib /usr/local/lib
+ENV LD_LIBRARY_PATH /usr/local/lib
+
+COPY --from=python-deps --chown=ftuser:ftuser /home/ftuser/.local /home/ftuser/.local
+
+USER ftuser
+# Install and execute
+COPY --chown=ftuser:ftuser . /freqtrade/
+
+RUN pip install -e . --user --no-cache-dir --no-build-isolation \
+  && mkdir /freqtrade/user_data/ \
+  && freqtrade install-ui
+
+ENTRYPOINT ["freqtrade"]
+# Default to trade mode
+CMD [ "trade" ]

--- a/astralionbot_test_strat.py
+++ b/astralionbot_test_strat.py
@@ -1,0 +1,310 @@
+# pragma pylint: disable=missing-docstring, invalid-name, pointless-string-statement
+# flake8: noqa: F401
+# isort: skip_file
+# --- Do not remove these libs ---
+import logging
+import numpy as np  # noqa
+import pandas as pd  # noqa
+from pandas import DataFrame
+
+from freqtrade.strategy import IStrategy
+from freqtrade.strategy import CategoricalParameter, DecimalParameter, IntParameter
+from freqtrade.optimize.space import Categorical, Dimension, Integer, SKDecimal, Real
+from freqtrade.persistence import Trade
+from freqtrade.optimize.hyperopt import IHyperOptLoss
+# --------------------------------
+# Add your lib to import here
+import talib.abstract as ta
+import freqtrade.vendor.qtpylib.indicators as qtpylib
+from functools import reduce
+from datetime import datetime, timedelta
+from typing import Dict, Any, Callable, List
+from talib import MA_Type
+logger = logging.getLogger(__name__)
+
+
+class CryptalStrategyOptimTrendRoiSharpe(IStrategy):
+    # Strategy interface version - allow new iterations of the strategy interface.
+    # Check the documentation or the Sample strategy to get the latest version.
+    INTERFACE_VERSION = 2
+
+    # Minimal ROI designed for the strategy.
+    minimal_roi = {
+        "0": 0.139,
+        "40": 0.051,
+        "53": 0.025,
+        "157": 0
+    }
+
+    # Stoploss:
+    stoploss = -0.324
+
+    # Trailing stop:
+    trailing_stop = True
+    trailing_stop_positive = 0.01
+    trailing_stop_positive_offset = 0.034
+    trailing_only_offset_is_reached = True
+
+    ### Hyperoptable parameters
+    # SPACE BUY
+    buy_adx = IntParameter(18, 32, default=30, optimize=True, space="buy")
+    buy_macd = IntParameter(-10, 20, default=15, optimize=False, space="buy")
+
+    # ENABLER BUY
+    #buy_trigger_macd_increase_enabled = CategoricalParameter([True, False], default=False, optimize=True, space="buy")
+    #buy_trigger_macd_enabled = CategoricalParameter([True, False], default=False, optimize=True, space="buy")
+    #buy_trigger_cross = CategoricalParameter(["macd", "no_cross_cond"], default="no_cross_cond", optimize=True, space="buy")
+
+    # SPACE SELL
+    sell_adx = IntParameter(18, 32, default=27, optimize=False, space="sell")
+    sell_stochrsi = IntParameter(60, 87, default=61, optimize=False, space="sell")
+    #sell_macd = IntParameter(0, 30, default=7, optimize=True, space="sell")
+
+    # ENABLER SELL
+    # REPLACE BOLLINGER by KELTNER
+    #sell_trigger_macd_decrease_enabled = CategoricalParameter([True, False], default=True, optimize=True, space="sell")
+
+    buy_ema_short_period = IntParameter(3, 9, default=8, optimize=False, space="buy")
+    #sell_ema_short_period = IntParameter(3, 9, default=5, optimize=True, space="sell")
+
+    buy_ema_long_period = IntParameter(12, 30, default=29, optimize=False, space="buy")
+    #sell_ema_long_period = IntParameter(9, 30, default=20, optimize=True, space="sell")
+
+    # Strategy for 5m timeframe.
+    timeframe = '1m'
+
+    # Run "populate_indicators()" only for new candle.
+    process_only_new_candles = False
+
+    # These values can be overridden in the "ask_strategy" section in the config.
+    use_sell_signal = True
+    sell_profit_only = True
+    #ignore_roi_if_buy_signal = True # Overridden
+
+    # Number of candles the strategy requires before producing valid signals
+    startup_candle_count: int = 500
+
+    # Optional order type mapping.
+    order_types = {
+        'buy': 'limit',
+        'sell': 'limit',
+        'stoploss': 'limit',
+        'stoploss_on_exchange': False, # Gérer le stoploss directement dans freqtrade pour éviter la latence imposée par Binance (d'autant plus si je n'utilise plus les bougies par la suite)
+        'stoploss_on_exchange_interval': 60,
+        'stoploss_on_exchange_limit_ratio': 0.995
+    }
+
+    # Optional order time in force.
+    order_time_in_force = {
+        'buy': 'gtc',
+        'sell': 'gtc'
+    }
+
+    plot_config = {
+        'main_plot': {
+            'tema': {},
+            'sar': {'color': 'white'},
+        },
+        'subplots': {
+            "MACD": {
+                'macd': {'color': 'blue'},
+                'macdsignal': {'color': 'orange'},
+            },
+            "RSI": {
+                'rsi': {'color': 'red'},
+            }
+        }
+    }
+
+    def informative_pairs(self):
+        """
+        Define additional, informative pair/interval combinations to be cached from the exchange.
+        These pair/interval combinations are non-tradeable, unless they are part
+        of the whitelist as well.
+        For more information, please consult the documentation
+        :return: List of tuples in the format (pair, interval)
+            Sample: return [("ETH/USDT", "5m"),
+                            ("BTC/USDT", "15m"),
+                            ]
+        """
+        return []
+
+    def populate_indicators(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
+        """
+        Adds several different TA indicators to the given DataFrame
+
+        Performance Note: For the best performance be frugal on the number of indicators
+        you are using. Let uncomment only the indicator you are using in your strategies
+        or your hyperopt configuration, otherwise you will waste your memory and CPU usage.
+        :param dataframe: Dataframe with data from the exchange
+        :param metadata: Additional information, like the currently traded pair
+        :return: a Dataframe with all mandatory indicators for the strategies
+        """
+
+        # Momentum Indicators
+        # ------------------------------------
+
+        # ADX
+        dataframe['adx'] = ta.ADX(dataframe, timeperiod=14)
+
+        # MACD
+        macd  = ta.MACD(dataframe, fastperiod=12, slowperiod=26, signalperiod=9)
+        dataframe['macd'] = macd['macd']
+        dataframe['macdsignal'] = macd['macdsignal']
+        dataframe['macdhist'] = macd['macdhist']
+        dataframe['macd_previous_s'] = dataframe['macd'].shift(1)
+
+        stoch_rsi = ta.STOCHRSI(dataframe, timeperiod=14, fastk_period=5, fastd_period=3, fastd_matype=0)
+        dataframe['fastk_rsi'] = stoch_rsi['fastk']
+        dataframe['fastd_rsi'] = stoch_rsi['fastd']
+
+        dataframe['rsi'] = ta.RSI(dataframe, timeperiod=14)
+
+        upperband, middleband, lowerband = ta.BBANDS(dataframe['close'], timeperiod=20, nbdevup=2.0, nbdevdn=2.0, matype=MA_Type.T3)
+        dataframe['bb_up'] = upperband
+        dataframe['bb_lw'] = lowerband
+        dataframe['bb_mid'] = middleband
+
+
+        dataframe["ema_5"] = ta.EMA(dataframe, timeperiod=5)
+        dataframe["ema_20"] = ta.EMA(dataframe, timeperiod=20)
+
+        k = 30
+        dataframe["ema_5_history"] = [
+            dataframe['ema_5'].iloc[max(0, i - k + 1):i + 1].tolist() 
+            for i in range(len(dataframe))
+        ]
+        dataframe["ema_20_history"] = [
+            dataframe['ema_20'].iloc[max(0, i - k + 1):i + 1].tolist() 
+            for i in range(len(dataframe))
+        ]
+
+        dataframe["ema_10"] = ta.EMA(dataframe, timeperiod=10)
+        dataframe["ema_50"] = ta.EMA(dataframe, timeperiod=50)
+
+        # Create a new column with arrays of current + 29 previous EMA-50 values
+        dataframe["ema_50_history"] = [
+            dataframe['ema_50'].iloc[max(0, i - k + 1):i + 1].tolist() 
+            for i in range(len(dataframe))
+        ]
+
+        dataframe["ema_10_history"] = [
+            dataframe['ema_10'].iloc[max(0, i - k + 1):i + 1].tolist() 
+            for i in range(len(dataframe))
+        ]
+
+        dataframe["chaikin_ad_osc"] = ta.ADOSC(dataframe, fastperiod=3, slowperiod=10)
+
+        fastk, fastd = ta.STOCHF(
+            dataframe["high"], dataframe["low"], dataframe["close"], fastk_period=14, fastd_period=3, fastd_matype=0
+        )
+        dataframe["fastk"] = fastk
+        dataframe["fastd"] = fastd
+
+        #if (metadata['pair'] == 'BTC/USDT'):
+        #    print(dataframe)
+        #    print(dataframe.columns)
+        #    dataframe['json'] = dataframe.apply(lambda x: str(x.to_json()), axis=1)
+        #    print(dataframe.tail(1)['json'].values[0])
+            #print(stoch_rsi)
+            #print(dataframe['fastk_rsi'])
+            #print(dataframe['ema_var'])
+            #print(dataframe.columns)
+            #print(metadata)
+
+        return dataframe
+
+    def populate_entry_trend(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
+        """
+        Based on TA indicators, populates the buy signal for the given dataframe
+        :param dataframe: DataFrame populated with indicators
+        :param metadata: Additional information, like the currently traded pair
+        :return: DataFrame with buy column
+        """
+        #conditions = []
+
+        # Some "BUY" conditions
+        #if self.buy_trigger_macd_enabled.value  and (not self.buy_trigger_cross.value == "macd") and (not self.buy_trigger_macd_increase_enabled.value) :
+        #    conditions.append(dataframe['macd'] > self.buy_macd.value /100)
+        #if self.buy_trigger_macd_increase_enabled.value and (not self.buy_trigger_macd_enabled.value) and (not self.buy_trigger_cross.value == "macd"): #MACD increase et redressement du signal
+        #if self.buy_trigger_macd_enabled.value:
+        #conditions.append(dataframe['macd'] > dataframe['macd_previous_s'])
+        #conditions.append(dataframe['macd_previous_s'] >= dataframe['macd_previous_l'])
+        #if self.buy_trigger_cross.value == "macd":
+        #    conditions.append(qtpylib.crossed_above(dataframe['macd'], self.buy_macd.value/100))
+
+        #### GUARDS CONDITIONS
+        #conditions.append((dataframe['volume'] > 0)) #& (dataframe['adx'] > self.buy_adx.value))
+
+        #if conditions:
+        #    dataframe.loc[(
+        #        reduce(lambda x, y: x & y, conditions)),
+        #        'buy'] = 1
+
+        dataframe.loc[(
+                (
+                    (qtpylib.crossed_above(dataframe['macd'], self.buy_macd.value/100))
+                    | (
+                        (dataframe[f'ema_10'] >= dataframe[f'ema_5'])
+                        & ((dataframe['macd'] > dataframe['macd_previous_s']) | ((dataframe['ema_5'] < dataframe['ema_5'])))
+                    )
+                )
+                & dataframe['volume'] > 0 & (dataframe['adx'] > self.buy_adx.value)
+            ),
+            ['enter_long', 'enter_tag']] = (1, 'rsi_cross')
+
+        return dataframe
+
+
+    def populate_exit_trend(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
+        """
+        Based on TA indicators, populates the sell signal for the given dataframe
+        :param dataframe: DataFrame populated with indicators
+        :param metadata: Additional information, like the currently traded pair
+        :return: DataFrame with sell column
+        """
+
+        #conditions = []
+
+        ### Some "SELL" conditions
+
+        #if self.sell_trigger_macd_decrease_enabled.value:
+        #if dataframe['ema5'] < dataframe['ema20']:
+        #    conditions.append(dataframe['macd'] < dataframe['macd_previous_s'])
+        #else:
+        #   # If increase period, allow more resilience if check two frames than one
+        #    conditions.append(dataframe['macd'] < dataframe['macd_previous_s'])
+        #    conditions.append(dataframe['macd_previous_s'] <= dataframe['macd_previous_l'])
+        #else:
+        #    conditions.append(qtpylib.crossed_below(dataframe['macd'], self.sell_macd.value/100))
+        
+        ### GUARDS CONDITIONS
+        #conditions.append(dataframe['volume'] > 0)# & (dataframe['adx'] > self.sell_adx.value))
+
+        #if conditions:
+        #    dataframe.loc[(
+        #        reduce(lambda x, y: x & y, conditions)),
+        #        'sell'] = 1
+        dataframe.loc[((
+                qtpylib.crossed_below(dataframe['fastk_rsi'], self.sell_stochrsi.value)
+                ) & dataframe['volume'] > 0 & (dataframe['adx'] > self.sell_adx.value)
+            ),
+            ['exit_long', 'exit_tag']] = (1, 'some_exit_tag')
+
+        return dataframe
+
+
+    #use_custom_stoploss = True
+#
+#
+    #def custom_stoploss(self, pair: str, trade: Trade, current_time: datetime,
+    #                    current_rate: float, current_profit: float, **kwargs) -> float:
+#
+    #    # Pour chaque pair, optimisation du trailing stoploss/stoploss
+    #    if (current_profit > 0.0) & (current_profit < self.stpl_limit_sup.value /100) :
+    #        return self.stpl_val_inter.value /100
+    #    elif current_profit >= self.stpl_limit_sup.value /100:
+    #        return self.stpl_val_sup.value /1000
+    #    elif current_profit <= 0.0:
+    #        return self.stpl_val_inf.value /100
+    #    return 3 /100

--- a/config_astralionbot_test.BAK
+++ b/config_astralionbot_test.BAK
@@ -1,0 +1,181 @@
+
+{
+    "$schema": "https://schema.freqtrade.io/schema.json",
+    "max_open_trades": 3,
+    "timeframe": "1m",
+    "dry_run": true,
+    "cancel_open_orders_on_exit": false,
+    "strategy_path" : "user_data/strategies",
+    "strategy" : "AstralionBotTestStrat",
+    "bid_strategy": {
+        "price_side": "ask",
+        "ask_last_balance": 0.0,
+        "use_order_book": false,
+        "order_book_top": 1,
+        "check_depth_of_market": {
+            "enabled": false,
+            "bids_to_ask_delta": 1
+        }
+    },
+    "ask_strategy": {
+        "price_side": "bid",
+        "use_order_book": false,
+        "order_book_min": 1,
+        "order_book_max": 1
+    },
+    "stake_currency": "USDT",
+    "stake_amount": 1000,
+    "tradable_balance_ratio": 0.99,
+    "fiat_display_currency": "USD",
+    "dry_run": true,
+    "dry_run_wallet": 3600,
+    "cancel_open_orders_on_exit": false,
+    "trading_mode": "spot",
+    "margin_mode": "",
+    "unfilledtimeout": {
+        "entry": 10,
+        "exit": 10,
+        "exit_timeout_count": 0,
+        "unit": "minutes"
+    },
+    "entry_pricing": {
+        "price_side": "same",
+        "use_order_book": true,
+        "order_book_top": 1,
+        "price_last_balance": 0.0,
+        "check_depth_of_market": {
+            "enabled": false,
+            "bids_to_ask_delta": 1
+        }
+    },
+    "exit_pricing":{
+        "price_side": "same",
+        "use_order_book": true,
+        "order_book_top": 1
+    },
+    "exchange": {
+        "name": "binance",
+        "key": "tffDcqP2NyWKMTSZHx80ApgLIlyYpyqjRniTekNuaQ1VEpNxmUNLNVJkYOv7rkQf",
+        "secret": "gnfcUY3AxhwItkljLxoqb3bEf5LFT8TZC525p2rKOMaaoAuPtb7AmL1DVCZTEskA",
+        "ccxt_config": {},
+        "ccxt_async_config": {},
+        "pair_whitelist": [
+            "ADA/USDT",
+            "ALGO/USDT",
+            "ALPHA/USDT",
+            "ATOM/USDT",
+            "AVA/USDT",
+            "BAKE/USDT",
+            "BCC/USDT",
+            "BCH/USDT",
+            "BEAM/USDT",
+            "BTC/USDT",
+            "BUSD/USDT",
+            "CAKE/USDT",
+            "COS/USDT",
+            "CVC/USDT",
+            "DAI/USDT",
+            "DASH/USDT",
+            "DATA/USDT",
+            "DOCK/USDT",
+            "DOGE/USDT",
+            "DOT/USDT",
+            "DNT/USDT",
+            "EOS/USDT",
+            "ETC/USDT",
+            "ETH/USDT",
+            "FIO/USDT",
+            "FUN/USDT",
+            "GTC/USDT",
+            "GTO/USDT",
+            "HIVE/USDT",
+            "IOTA/USDT",
+            "LINK/USDT",
+            "LRC/USDT",
+            "LTC/USDT",
+            "LUNA/USDT",
+            "MATIC/USDT",
+            "MDT/USDT",
+            "MKR/USDT",
+            "NANO/USDT",
+            "NEAR/USDT",
+            "NEO/USDT",
+            "ONE/USDT",
+            "POND/USDT",
+            "QTUM/USDT",
+            "REEF/USDT",
+            "SHIB/USDT",
+            "STRAX/USDT",
+            "THETA/USDT",
+            "TROY/USDT",
+            "TRX/USDT",
+            "VET/USDT",
+            "WRX/USDT",
+            "XLM/USDT",
+            "XRP/USDT",
+            "ZRX/USDT"
+        ],
+        "pair_blacklist": [
+            "BNB/.*"
+        ]
+    },
+    "pairlists": [
+        {
+            "method": "VolumePairList",
+            "number_assets": 20,
+            "sort_key": "quoteVolume",
+            "min_value": 0,
+            "refresh_period": 1800
+        }
+    ],
+    "telegram": {
+        "enabled": false,
+        "token": "",
+        "chat_id": ""
+    },
+    "api_server": {
+        "enabled": true,
+        "listen_ip_address": "127.0.0.1",
+        "listen_port": 8080,
+        "verbosity": "error",
+        "enable_openapi": false,
+        "jwt_secret_key": "9c79db0218f1a7c0bf13035a2b4a18ae8f8a3c7e28b11fb690d796feef803839",
+        "ws_token": "ZK7y4q7vBg4d7wxuUvMOFMEjozKge2jFjQ",
+        "CORS_origins": [],
+        "username": "freqtrader",
+        "password": "test"
+    },
+    "external_mqtt_server": {
+        "enabled": true,
+        "host": "k45f49f2.ala.us-east-1.emqxsl.com",
+        "port": 8883,
+        "protocol": "tls",
+        "username": "testt3st",
+        "password": "testt3st",
+        "topic": "freqtrade/messages",
+        "retain": true,
+        "pool_size": 2,
+        "client_id_prefix": "astralionbot_",
+        "allow_custom_messages": true
+    },
+    "datadir": "user_data/data/binance",
+    "logfile": "user_data/logs/freqtrade.log",
+    "pairlists": [
+        {"method": "StaticPairList"},
+        {"method": "AgeFilter", "min_days_listed": 30},
+        {"method": "ShuffleFilter", "seed": 42},
+        //{"method": "PrecisionFilter"},
+        {
+            "method": "RangeStabilityFilter",
+            "lookback_days": 3,
+            "min_rate_of_change": 0.02,
+            "refresh_period": 1440
+        }
+    ],
+    "bot_name": "astralionbot-test",
+    "initial_state": "running",
+    "force_entry_enable": false,
+    "internals": {
+        "process_throttle_secs": 5
+    }
+}

--- a/freqtrade/rpc/mqtt_client.py
+++ b/freqtrade/rpc/mqtt_client.py
@@ -1,0 +1,243 @@
+"""
+This module contains the MqttClient class, which handles external MQTT messaging
+"""
+
+import json
+import logging
+from queue import Queue
+from threading import Lock
+from typing import Any, Dict, Optional
+import uuid
+from datetime import datetime
+
+from freqtrade.constants import PairWithTimeframe
+from freqtrade.enums.rpcmessagetype import RPCMessageType
+from freqtrade.exceptions import OperationalException
+from freqtrade.rpc.rpc import RPC
+import paho.mqtt.client as mqtt
+
+from freqtrade.rpc import RPCHandler
+from freqtrade.rpc.rpc_types import RPCSendMsg
+
+
+logger = logging.getLogger(__name__)
+
+
+class DateTimeEncoder(json.JSONEncoder):
+    """Custom JSON encoder for datetime objects"""
+
+    def default(self, obj):
+        if isinstance(obj, datetime):
+            return obj.isoformat()
+        return super().default(obj)
+
+
+class MqttConnection:
+    """
+    Represents a single MQTT connection in the pool
+    """
+
+    def __init__(self, config: Dict[str, Any], short_uuid: str, connection_num: int):
+        mqtt_config = config.get("external_mqtt_server", {})
+        client_id_prefix = mqtt_config.get("client_id_prefix", "freqtrade_")
+        client_id = f"{client_id_prefix}{short_uuid}_{connection_num}"
+
+        self.client = mqtt.Client(client_id=client_id, reconnect_on_failure=True)
+        self.config = config
+        self.in_use = False
+        self.setup_client()
+
+    def setup_client(self):
+        """Configure and connect the MQTT client"""
+        mqtt_config = self.config.get("external_mqtt_server", {})
+        self.client.username_pw_set(mqtt_config.get("username"), mqtt_config.get("password"))
+
+        if mqtt_config.get("protocol", "").lower() == "tls":
+            self.client.tls_set()
+
+        try:
+            self.client.connect(mqtt_config.get("host", "localhost"), mqtt_config.get("port", 1883))
+            self.client.loop_start()
+        except Exception as e:
+            logger.error(f"Error connecting to MQTT broker: {e}")
+            raise
+
+
+class MqttClient(RPCHandler):
+    """
+    MQTT client class handling message publication to an external MQTT broker
+    """
+
+    # Initialize class variables
+    _has_rpc: bool = False
+    _rpc: RPC = None
+
+    def __init__(self, config: Dict[str, Any]) -> None:
+        """
+        Initialize MQTT client
+        """
+        self._config = config
+        self._name = "external_mqtt_server"
+
+        self._pool_size = config.get("external_mqtt_server", {}).get("pool_size", 10)
+        self._connection_pool: list[MqttConnection] = []
+        self._pool_lock = Lock()
+        self._message_queue: Queue = Queue()
+
+        self._mqtt_config = self._config.get("external_mqtt_server", {})
+        self._exchange_name = self._config.get("exchange", {}).get("name", "")
+        self._retain: bool = self._mqtt_config.get("retain", False)
+        self._short_uuid = str(uuid.uuid4())[:8]
+
+        # Add tracking for sent records - using list instead of set to maintain order
+        self._sent_records: Dict[str, list] = {}
+        self._max_records_per_topic = 3  # Keep only last 3 records
+
+        # Initialize connection pool
+        self._initialize_pool()
+
+    def _initialize_pool(self) -> None:
+        """Initialize the connection pool with MQTT clients"""
+        try:
+            for i in range(self._pool_size):
+                connection = MqttConnection(self._config, self._short_uuid, i)
+                self._connection_pool.append(connection)
+        except Exception as e:
+            logger.error(f"Failed to initialize MQTT connection pool: {e}")
+            raise
+
+    def _get_connection(self) -> Optional[MqttConnection]:
+        """Get an available connection from the pool"""
+        with self._pool_lock:
+            for conn in self._connection_pool:
+                if not conn.in_use:
+                    conn.in_use = True
+                    return conn
+        return None
+
+    def _release_connection(self, connection: MqttConnection) -> None:
+        """Release a connection back to the pool"""
+        with self._pool_lock:
+            connection.in_use = False
+
+    def add_rpc_handler(self, rpc: RPC):
+        """
+        Attach rpc handler
+        """
+        if not MqttClient._has_rpc:
+            MqttClient._rpc = rpc
+            MqttClient._has_rpc = True
+        else:
+            # This should not happen assuming we didn't mess up.
+            raise OperationalException("RPC Handler already attached.")
+
+    def cleanup(self) -> None:
+        """
+        Cleanup pending connections and messages
+        """
+        logger.info("Cleaning up MQTT connections...")
+        for conn in self._connection_pool:
+            try:
+                conn.client.loop_stop()
+                conn.client.disconnect()
+            except Exception as e:
+                logger.error(f"Error during MQTT cleanup: {e}")
+
+    def _is_record_sent(self, topic: str, record: dict) -> bool:
+        """
+        Check if a record has already been sent
+        Returns True if record was already sent, False otherwise
+        Maintains only the last N records per topic
+        """
+        # Create a unique key for the record based on timestamp and other relevant fields
+        record_key = f"{record.get('date')}_{record.get('open')}_{record.get('close')}"
+
+        if topic not in self._sent_records:
+            self._sent_records[topic] = []
+
+        # Check if record exists in the last N records
+        if record_key in self._sent_records[topic]:
+            return True
+
+        # Add new record and maintain only last N records
+        self._sent_records[topic].append(record_key)
+        if len(self._sent_records[topic]) > self._max_records_per_topic:
+            self._sent_records[topic].pop(0)  # Remove oldest record
+
+        return False
+
+    def send_msg(self, msg: RPCSendMsg) -> None:
+        """
+        Send given message to MQTT broker
+        """
+        if msg.get("type") == RPCMessageType.ANALYZED_DF:
+            pairWmetadata: PairWithTimeframe = msg["data"]["key"]
+            renamed_pair = pairWmetadata[0].replace("/", "-")
+            records: list = msg["data"]["df"].to_dict(orient="records")
+
+            base_topic: str = f"crypto/{self._exchange_name}/{pairWmetadata[1]}/{renamed_pair}"
+
+            connection = self._get_connection()
+            if not connection:
+                print("No available MQTT connections in pool. Message queued.")
+                logger.warning("No available MQTT connections in pool. Message queued.")
+                self._message_queue.put((base_topic, msg, self._retain))
+                return
+
+            try:
+                for record in records:
+                    # Skip if record was already sent
+                    if self._is_record_sent(base_topic, record):
+                        continue
+
+                    indicator_msg = {
+                        "pair": renamed_pair,
+                        "exchange": self._exchange_name,
+                        "timeframe": pairWmetadata[1],
+                        **record,
+                    }
+
+                    # Publish the message with custom JSON encoder
+                    connection.client.publish(
+                        base_topic, json.dumps(indicator_msg, cls=DateTimeEncoder), qos=1, retain=self._retain
+                    )
+                    logger.debug(f"Published indicators to MQTT topic {base_topic}")
+
+            except Exception as e:
+                print(f"Error publishing message to MQTT: {e}")
+                logger.error(f"Error publishing message to MQTT: {e}")
+            finally:
+                self._release_connection(connection)
+
+            # Process queued messages if any
+            while not self._message_queue.empty():
+                try:
+                    topic, queued_msg, retain = self._message_queue.get_nowait()
+                    self.send_msg(queued_msg)
+                except Exception as e:
+                    print(f"Error processing queued MQTT message: {e}")
+                    logger.error(f"Error processing queued MQTT message: {e}")
+
+    @property
+    def name(self) -> str:
+        """Returns the name of the handler"""
+        return self._name
+
+
+# """
+# {
+#     "external_mqtt_server": {
+#         "enabled": true,
+#         "host": "your.mqtt.broker.com",
+#         "port": 8883,
+#         "protocol": "tls",
+#         "username": "your_username",
+#         "password": "your_password",
+#         "topic": "freqtrade/messages",
+#         "retain": false,
+#         "pool_size": 10,
+#         "client_id_prefix": "freqtrade_",
+#         "allow_custom_messages": true
+#     }
+# }
+# """

--- a/freqtrade/rpc/mqtt_client.py
+++ b/freqtrade/rpc/mqtt_client.py
@@ -4,19 +4,19 @@ This module contains the MqttClient class, which handles external MQTT messaging
 
 import json
 import logging
-from queue import Queue
-from threading import Lock
-from typing import Any, Dict, Optional
 import uuid
 from datetime import datetime
+from queue import Queue
+from threading import Lock
+from typing import Any
+
+import paho.mqtt.client as mqtt
 
 from freqtrade.constants import PairWithTimeframe
 from freqtrade.enums.rpcmessagetype import RPCMessageType
 from freqtrade.exceptions import OperationalException
-from freqtrade.rpc.rpc import RPC
-import paho.mqtt.client as mqtt
-
 from freqtrade.rpc import RPCHandler
+from freqtrade.rpc.rpc import RPC
 from freqtrade.rpc.rpc_types import RPCSendMsg
 
 
@@ -37,7 +37,7 @@ class MqttConnection:
     Represents a single MQTT connection in the pool
     """
 
-    def __init__(self, config: Dict[str, Any], short_uuid: str, connection_num: int):
+    def __init__(self, config: dict[str, Any], short_uuid: str, connection_num: int):
         mqtt_config = config.get("external_mqtt_server", {})
         client_id_prefix = mqtt_config.get("client_id_prefix", "freqtrade_")
         client_id = f"{client_id_prefix}{short_uuid}_{connection_num}"
@@ -72,7 +72,7 @@ class MqttClient(RPCHandler):
     _has_rpc: bool = False
     _rpc: RPC = None
 
-    def __init__(self, config: Dict[str, Any]) -> None:
+    def __init__(self, config: dict[str, Any]) -> None:
         """
         Initialize MQTT client
         """
@@ -90,7 +90,7 @@ class MqttClient(RPCHandler):
         self._short_uuid = str(uuid.uuid4())[:8]
 
         # Add tracking for sent records - using list instead of set to maintain order
-        self._sent_records: Dict[str, list] = {}
+        self._sent_records: dict[str, list] = {}
         self._max_records_per_topic = 3  # Keep only last 3 records
 
         # Initialize connection pool
@@ -106,7 +106,7 @@ class MqttClient(RPCHandler):
             logger.error(f"Failed to initialize MQTT connection pool: {e}")
             raise
 
-    def _get_connection(self) -> Optional[MqttConnection]:
+    def _get_connection(self) -> MqttConnection | None:
         """Get an available connection from the pool"""
         with self._pool_lock:
             for conn in self._connection_pool:
@@ -199,7 +199,8 @@ class MqttClient(RPCHandler):
 
                     # Publish the message with custom JSON encoder
                     connection.client.publish(
-                        base_topic, json.dumps(indicator_msg, cls=DateTimeEncoder), qos=1, retain=self._retain
+                        base_topic, json.dumps(indicator_msg, cls=DateTimeEncoder), qos=1,
+                        retain=self._retain
                     )
                     logger.debug(f"Published indicators to MQTT topic {base_topic}")
 

--- a/freqtrade/rpc/rpc_manager.py
+++ b/freqtrade/rpc/rpc_manager.py
@@ -54,6 +54,15 @@ class RPCManager:
             apiserver.add_rpc_handler(self._rpc)
             self.registered_modules.append(apiserver)
 
+        # Enable local rest api server for cmd line control
+        if config.get("external_mqtt_server", {}).get("enabled", False):
+            logger.info("Enabling rpc.external_mqtt_server")
+            from freqtrade.rpc.mqtt_client import MqttClient
+
+            mqttclient = MqttClient(config)
+            mqttclient.add_rpc_handler(self._rpc)
+            self.registered_modules.append(mqttclient)
+
     def cleanup(self) -> None:
         """Stops all enabled rpc modules"""
         logger.info("Cleaning up rpc modules ...")

--- a/requirements.txt
+++ b/requirements.txt
@@ -44,6 +44,8 @@ uvicorn==0.34.0
 pyjwt==2.10.1
 aiofiles==24.1.0
 psutil==6.1.1
+# MQTT
+paho-mqtt==2.1.0
 
 # Building config files interactively
 questionary==2.1.0


### PR DESCRIPTION
<!-- Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)
-->
## Summary

<!-- Explain in one sentence the goal of this PR -->

Add MQTT support using `paho-mqtt` lib to push `analyzed_dataframe` data external MQTT server.

## Quick changelog

- Add mqtt connection and mqtt client
- Update `rpc_manager` to support mqtt client

## What's new?

Ability to push data to external mqtt server (self-hosted, EMQX, HiveMQ...) using this configuration:

```yaml
    "external_mqtt_server": {
        "enabled": true,
        "host": "k45f49f2.ala.us-east-1.emqxsl.com",
        "port": 8883,
        "protocol": "tls",
        "username": "testt3st",
        "password": "testt3st",
        "topic": "freqtrade/messages",
        "retain": true,
        "pool_size": 2,
        "client_id_prefix": "freqbot1_",
        "allow_custom_messages": true
    },
```
